### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ results = autoscheduler.execute(scheduled_circuit,shots,'local',times)
 
 Here is a basic example on how to use Autoscheduler with a Braket circuit.
 ```python
-# Import Autoscheduler library and neccesary Braket libraries
+# Import Autoscheduler library and necessary Braket libraries
 from autoscheduler import Autoscheduler
 from braket.circuits import Circuit
 
@@ -93,7 +93,7 @@ results = autoscheduler.execute(scheduled_circuit,shots,machine,times)
 Here is a basic example on how to use Autoscheduler with a Qiskit circuit.
 ```python
 
-# Import Autoscheduler library and neccesary Qiskit libraries
+# Import Autoscheduler library and necessary Qiskit libraries
 from autoscheduler import Autoscheduler
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 
@@ -128,7 +128,7 @@ scheduled_circuit, shots, times = autoscheduler.schedule(circuit, shots, max_qub
 results = autoscheduler.execute(scheduled_circuit,shots,machine,times)
 ```
 
-It it possible to use the method schedule_and_execute instead of schedule and then execute, this method needs to have the machine in which you want to execute the circuit as a mandatory input. If the execution is on a aws machine, it is needed to specify the s3 bucket too. Also, provider is only needed when using Quirk URLs.
+It is possible to use the method schedule_and_execute instead of schedule and then execute, this method needs to have the machine in which you want to execute the circuit as a mandatory input. If the execution is on a aws machine, it is needed to specify the s3 bucket too. Also, provider is only needed when using Quirk URLs.
 
 ```python
 from autoscheduler import Autoscheduler
@@ -230,11 +230,11 @@ QCRAFT AutoScheduler will utilize the default AWS and IBM Cloud credentials stor
 This library aims for the shot optimization on quantum tasks. Reducing the cost of the circuit on the end-user.
 
 ### Shot optimization
-To achieve the shot optimization, the original circuit will be composed multiple time with itself. The more segments, the less shots will be needed to replicate the original circuit.
+To achieve the shot optimization, the original circuit will be composed multiple times with itself. The more segments, the less shots will be needed to replicate the original circuit.
 The total number of shots may differ from the original on a very small scale because the library combines the original circuit multiple times. Depending on the maximum number of qubits, to achieve the desired number of shots and cost reduction the algorithm will create segments equal to the original circuit each with a proportional number of shots, all this on a unique circuit.
 
 **Example:**
-Consider a circuit with 2 qubits, requiring 100 shots. If the maximum number of qubits of the new scheduled circuit is 6, the shots will be reduced to 100/(6/2) = 34 in total. Upon uncheduling, the results of each segment of the circuit will be aggregated, resulting on 34*(6/2) = 102 shots in total. Even so, the cost reduction has been achieved because the number of shots has been reduced from 100 to 34.
+Consider a circuit with 2 qubits, requiring 100 shots. If the maximum number of qubits of the new scheduled circuit is 6, the shots will be reduced to 100/(6/2) = 34 in total. Upon unscheduling, the results of each segment of the circuit will be aggregated, resulting on 34*(6/2) = 102 shots in total. Even so, the cost reduction has been achieved because the number of shots has been reduced from 100 to 34.
 
 ## Changelog
 The changelog is available [here](https://github.com/Qcraft-UEx/QCRAFT-AutoScheduler/blob/main/CHANGELOG.md)

--- a/autoscheduler/_executeCircuitAWS.py
+++ b/autoscheduler/_executeCircuitAWS.py
@@ -30,7 +30,7 @@ def _recover_task_result(task_load: AwsQuantumTask) -> dict:
         
         time.sleep(1)
         sleep_times = sleep_times + 1
-    print("Quantum execution time exceded")
+    print("Quantum execution time exceeded")
     return None
 
 def _runAWS(machine:str, circuit:Circuit, shots:int, s3_bucket: Optional[tuple] = None) -> dict:

--- a/autoscheduler/_translator.py
+++ b/autoscheduler/_translator.py
@@ -1,12 +1,12 @@
 """
-Module containing qirk translator functions
+Module containing quirk translator functions
 """
 import ast
 from urllib.parse import unquote
 
 def _get_ibm_individual(ind_circuit:str,d:int) -> str:
     """
-    Translates the results of the Quirk URL into a Qiskit circuit, adding a offset to the qubits.
+    Translates the results of the Quirk URL into a Qiskit circuit, adding an offset to the qubits.
 
     Args:
         ind_circuit (str): The Quirk URL.
@@ -92,7 +92,7 @@ def _get_ibm_individual(ind_circuit:str,d:int) -> str:
 
 def _get_aws_individual(ind_circuit:str, d:int) -> str:
     """
-    Translates the results of the Quirk URL into a Braket circuit, adding a offset to the qubits.
+    Translates the results of the Quirk URL into a Braket circuit, adding an offset to the qubits.
 
     Args:
         ind_circuit (str): The Quirk URL.

--- a/autoscheduler/autoscheduler.py
+++ b/autoscheduler/autoscheduler.py
@@ -35,7 +35,7 @@ class Autoscheduler:
     def schedule(self, circuit: Union[qiskit.QuantumCircuit, Circuit, str], shots:int, machine: Optional[str] = None, max_qubits:Optional[int] = None, provider: Optional[str] = None) -> Tuple[Union[qiskit.QuantumCircuit, Circuit], int, int]:
          # Compose the circuit, it can be a circuit, github url of a circuit or quirk url of a circuit
         """
-        Composes the circuit multiple time to reduce the number of shots needed to execute the circuit.
+        Composes the circuit multiple times to reduce the number of shots needed to execute the circuit.
 
         Args:
             circuit (qiskit.QuantumCircuit | braket.circuits.Circuit | str): The circuit that will be scheduled, it can be a Qiskit circuit, Braket circuit, GitHub raw URL with a circuit or a Quirk URL.
@@ -123,14 +123,14 @@ class Autoscheduler:
 
     def schedule_and_execute(self, circuit:Union[qiskit.QuantumCircuit, Circuit, str], shots:int, machine:str, max_qubits:Optional[int] = None, provider:Optional[str] = None, s3_bucket:Optional[tuple] = None) -> dict: # Compose the circuit
         """
-        Composes the circuit multiple time to reduce the number of shots needed to execute the circuit and also executes it.
+        Composes the circuit multiple times to reduce the number of shots needed to execute the circuit and also executes it.
 
         Args:
             circuit (qiskit.QuantumCircuit | braket.circuits.Circuit | str): The circuit that will be scheduled and later executed, it can be a Qiskit circuit, Braket circuit, GitHub raw URL with a circuit or a Quirk URL.
             shots (int): The initial number of shots that the composed circuit will be executed.
             machine (str): The machine that will execute the circuit. It can be 'local' or the name of the machine on 'ibm' or 'aws'. For 'aws' it can be either the name or the ARN of the machine.
             max_qubits (int, optional): The maximum number of qubits that the composed circuit can have. If None, the qubits will be inferred from `machine`.
-            provider (str, optional): The provider of the circuit. It can be 'ibm', 'aws' or None. If None, it will be inferred from the circuit, it it only mandatory when Quirk URL is used.
+            provider (str, optional): The provider of the circuit. It can be 'ibm', 'aws' or None. If None, it will be inferred from the circuit, it is only mandatory when Quirk URL is used.
             s3_bucket (tuple, optional): The S3 bucket where the results will be stored. It is only mandatory when `machine` is not 'local' and the circuit will be executed on aws. The format is ('bucket-name', 'folder-name').
 
         Returns:
@@ -430,7 +430,7 @@ class Autoscheduler:
             qubits = [0] * num_qubits
             for line in circuit.split('\n'): # For each line in the circuit
                 if 'measure' not in line and 'barrier' not in line: #If the line is not a measure or a barrier
-                    # Check the numbers after qreg_q and add 1 to qubits on that position. It should work with whings like circuit.cx(qreg_q[0], qreg_q[3]), adding 1 to both 0 and 3
+                    # Check the numbers after qreg_q and add 1 to qubits on that position. It should work with things like circuit.cx(qreg_q[0], qreg_q[3]), adding 1 to both 0 and 3
                     # This adds 1 to the number of gates used on that qubit
                     for match in re.finditer(r'qreg_q\[(\d+)\]', line):
                         qubits[int(match.group(1))] += 1
@@ -486,7 +486,7 @@ class Autoscheduler:
 
     def _compose_circuit(self, max_qubits:int, qubits:int, circuit:Union[qiskit.QuantumCircuit, Circuit], shots:int, provider:str) -> Tuple[Union[qiskit.QuantumCircuit, Circuit],int,int]:
         """
-        Composes a quantum circuit based on a an object multiple times.
+        Composes a quantum circuit based on an object multiple times.
 
         Args:
             max_qubits (int): The maximum number of qubits that the composed circuit can have.

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -22,11 +22,11 @@ This library aims for the shot optimization on quantum tasks. Reducing the cost 
 
 Shot optimization
 -----------------
-To achieve the shot optimization, the original circuit will be composed multiple time with itself. The more segments, the less shots will be needed to replicate the original circuit.
+To achieve the shot optimization, the original circuit will be composed multiple times with itself. The more segments, the less shots will be needed to replicate the original circuit.
 The total number of shots may differ from the original on a very small scale because the library combines the original circuit multiple times. Depending on the maximum number of qubits, to achieve the desired number of shots and cost reduction the algorithm will create segments equal to the original circuit each with a proportional number of shots, all this on a unique circuit.
 
 **Example:**
-Consider a circuit with 2 qubits, requiring 100 shots. If the maximum number of qubits of the new scheduled circuit is 6, the shots will be reduced to 100/(6/2) = 34 in total. Upon uncheduling, the results of each segment of the circuit will be aggregated, resulting on 34*(6/2) = 102 shots in total. Even so, the cost reduction has been achieved because the number of shots has been reduced from 100 to 34.
+Consider a circuit with 2 qubits, requiring 100 shots. If the maximum number of qubits of the new scheduled circuit is 6, the shots will be reduced to 100/(6/2) = 34 in total. Upon unscheduling, the results of each segment of the circuit will be aggregated, resulting on 34*(6/2) = 102 shots in total. Even so, the cost reduction has been achieved because the number of shots has been reduced from 100 to 34.
 
 Getting Started
 ===============

--- a/tests/test_autoscheduler.py
+++ b/tests/test_autoscheduler.py
@@ -190,7 +190,7 @@ class TestAutoScheduler(unittest.TestCase):
                 circuit.x(  1)    
                 circuit.x(2)
                 circuit.x( 3 )      
-                circuit.cnot(2, 1) # chaning qubit 1
+                circuit.cnot(2, 1) # changing qubit 1
                 circuit.cnot( 1 ,2) #
                 circuit.cnot(2,1)  # 121
                 circuit.cnot(1,0) # 4

--- a/validation/ibm/plot-results.py
+++ b/validation/ibm/plot-results.py
@@ -57,7 +57,7 @@ def plot_and_save(all_distances):
     ax.set_xlabel('Algorithm')
     plt.xticks(rotation=45)  #Rotate the x-axis labels for better readability
     plt.tight_layout()
-    #Sets filename and saves the flot
+    #Sets filename and saves the plot
     filename = os.path.join(base_dir, 'hellinger.png')
     plt.savefig(filename, bbox_inches='tight')
     plt.close()
@@ -73,7 +73,7 @@ def handle_file(dir):
         with open(filepath, 'r') as file:
             key = os.path.splitext(os.path.basename(filepath))[0]
             content_dict = ast.literal_eval(file.read())
-            #Convert frequencies into probaiblity distributions to use the hellinger distance
+            #Convert frequencies into probability distributions to use the hellinger distance
             dist[key] = counts_to_probabilities(content_dict)
 
     return dist


### PR DESCRIPTION
## Summary
**Fix typos**
- neccesary -> necessary
- It it -> It is
- multiple time -> multiple times
- time exceded -> time exceeded
- qirk translator -> quirk translator
- a offset -> an offset
- whings -> things
- uncheduling -> unscheduling
- chaning -> changing
- flot -> plot
- probaiblity -> probability